### PR TITLE
Move pluginutils from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
   "author": "pakholeung37@gmail.com",
   "license": "MIT",
   "peerDependencies": {
-    "vite": "^2.0.4"
+    "vite": "^2.0.4",
+    "@rollup/pluginutils": "^4.1.1"
   },
   "devDependencies": {
-    "@rollup/pluginutils": "^4.1.1",
     "@types/jest": "^24.0.19",
     "@typescript-eslint/eslint-plugin": "^5.4.0",
     "@typescript-eslint/parser": "^5.4.0",

--- a/package.json
+++ b/package.json
@@ -26,9 +26,11 @@
   ],
   "author": "pakholeung37@gmail.com",
   "license": "MIT",
+  "dependencies": {
+    "@rollup/pluginutils": "^4.1.1"
+   },
   "peerDependencies": {
     "vite": "^2.0.4",
-    "@rollup/pluginutils": "^4.1.1"
   },
   "devDependencies": {
     "@types/jest": "^24.0.19",


### PR DESCRIPTION
@rollup/pluginutils are needed at runtime when the plugin is used, so they should be in the dependencies.


Thanks for this small plugin, saved me quite some headache already :)
