### PR TITLE
Do not apply to .json files by default

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ export function treatAsCommonjs(options?: {
 }): Plugin {
   const { include, exclude } = options ?? {}
   const filter = createFilter(
-    include || /node_modules\/.*\.[jt]sx?/,
+    include || /node_modules\/.*\.[jt]sx?(\?.*)?$/,
     exclude || []
   );
 


### PR DESCRIPTION
Applying this code modification to json files invalidates them. The regexp group is for allowing ids like file.js?v=12345.
